### PR TITLE
added messagebox for second instance lock

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -53,6 +53,3 @@ function getTimeStamp()
     var dt = new Date()
     return ("VS "+dt.getDate()+"-"+(dt.getMonth()+1)+"-"+dt.getFullYear()+" "+dt.getHours()+"."+dt.getMinutes()+"."+dt.getSeconds());
 }
-ipcRenderer.on("Second Instance" , (event, arg) => {
-    alert("VeritaSnap Is Already Running. Use Ctrl+Shift+P to take screenshot.")
-});

--- a/main.js
+++ b/main.js
@@ -1,6 +1,12 @@
-const { app,Menu, BrowserWindow,globalShortcut,ipcMain,Tray, nativeImage} = require('electron')
+const { app,Menu, BrowserWindow,globalShortcut,ipcMain,Tray, nativeImage,dialog} = require('electron')
 const path = require('path')
 const sound = require("sound-play");
+const options_for_second_instance_lock = {
+  type: 'info',
+  buttons: ['OK'],
+  title: 'Already Running',
+  message: 'VeritaSnap Is Already Running. Use Ctrl+Shift+P to take screenshot.',
+};
 let win
 
 const soundeffectpath = path.join(process.resourcesPath, "shutter.mp3");
@@ -41,7 +47,7 @@ if (!gotTheLock) {
 } else {
   app.on('second-instance', (event, commandLine, workingDirectory) => {
     // Someone tried to run a second instance, we should focus our window.
-    win.webContents.send("Second Instance");
+    dialog.showMessageBox(null, options_for_second_instance_lock);
     return;
   })
 }


### PR DESCRIPTION
Earlier `ipcrenderer` was used to send a message to `index.js` and then `alert()` was used to display the message.
This is not needed because `dialog.messagebox()` can be used from `main.js` itself to display the message.
No IPC is needed so I removed it.